### PR TITLE
Add single executable build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ Output:
 npx @charliewilco/mf-cli hello.ts
 ```
 
+### Building a single executable
+
+Node's single executable app builder is available in Node `>=25.5`. To build a standalone `mf` binary from this repository:
+
+```sh
+npm run build:sea
+./dist/mf ./src/components/Button.js
+```
+
+The generated binary is written to `dist/mf` or `dist/mf.exe` on Windows. The build keeps the published package runtime requirement at Node `>=24`; only the single-executable build step requires Node `>=25.5`.
+
 ## Rationale
 
 One command line thing I need to do all the time is make a file. In Atom when you make a new file, it'll make a new directory if it doesn't exist. For example if you're in Atom and make `src/components/Button.js` and the `components` directory doesn't exist, it'll just create it by default.

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -12,6 +12,6 @@
 		"verbatimModuleSyntax": true,
 		"skipLibCheck": true
 	},
-	"include": ["*.js"],
+	"include": ["*.js", "scripts/*.js"],
 	"exclude": ["dist", "node_modules"]
 }

--- a/package.json
+++ b/package.json
@@ -12,12 +12,14 @@
 	"preferGlobal": true,
 	"files": [
 		"./cli.js",
-		"./index.js"
+		"./index.js",
+		"./scripts/build-sea.js"
 	],
 	"bin": {
 		"mf": "./cli.js"
 	},
 	"scripts": {
+		"build:sea": "node scripts/build-sea.js",
 		"check": "tsc -p jsconfig.json",
 		"lint": "npx prettier . --check",
 		"test": "node --test test.js",

--- a/scripts/build-sea.js
+++ b/scripts/build-sea.js
@@ -1,0 +1,136 @@
+// @ts-check
+import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+const distDir = join(projectRoot, "dist");
+const seaEntry = join(distDir, "mf-sea.mjs");
+const seaConfig = join(distDir, "sea-config.json");
+const executable = join(distDir, process.platform === "win32" ? "mf.exe" : "mf");
+
+function assertBuildSeaSupport() {
+	const [major = 0, minor = 0] = process.versions.node.split(".").map(Number);
+
+	if (major > 25 || (major === 25 && minor >= 5)) {
+		return;
+	}
+
+	throw new Error(
+		`Node ${process.versions.node} cannot build single executable apps with --build-sea. Use Node >=25.5 for npm run build:sea.`,
+	);
+}
+
+/**
+ * @param {string} source
+ * @returns {string[]}
+ */
+function getImports(source) {
+	return [...source.matchAll(/^import .+;$/gmu)].map(([line]) => line);
+}
+
+/**
+ * @param {string} source
+ */
+function removeImports(source) {
+	return source.replace(/^import .+;\n/gmu, "");
+}
+
+/**
+ * @param {string} source
+ */
+function prepareIndexSource(source) {
+	return removeImports(source)
+		.replace(/^\/\/ @ts-check\n/u, "")
+		.replaceAll("export async function", "async function")
+		.replaceAll("export function", "function");
+}
+
+/**
+ * @param {string} source
+ */
+function prepareCliSource(source) {
+	return removeImports(source)
+		.replace(/^#!.+\n/u, "")
+		.replace(/^"use strict";\n/u, "")
+		.replace(/^\/\/ @ts-check\n/u, "");
+}
+
+/**
+ * @param {string} command
+ * @param {string[]} args
+ */
+async function run(command, args) {
+	await new Promise((resolve, reject) => {
+		const child = spawn(command, args, {
+			cwd: projectRoot,
+			stdio: "inherit",
+		});
+
+		child.on("error", reject);
+		child.on("exit", (code) => {
+			if (code === 0) {
+				resolve(undefined);
+				return;
+			}
+
+			reject(new Error(`${command} ${args.join(" ")} exited with ${code}`));
+		});
+	});
+}
+
+async function build() {
+	assertBuildSeaSupport();
+
+	const [indexSource, cliSource] = await Promise.all([
+		readFile(join(projectRoot, "index.js"), "utf8"),
+		readFile(join(projectRoot, "cli.js"), "utf8"),
+	]);
+
+	const imports = [...new Set([...getImports(indexSource), ...getImports(cliSource)])]
+		.filter((line) => !line.includes('"./index.js"'))
+		.join("\n");
+
+	const entry = `${imports}
+
+${prepareIndexSource(indexSource)}
+
+${prepareCliSource(cliSource)}
+`;
+
+	await rm(distDir, { recursive: true, force: true });
+	await mkdir(distDir, { recursive: true });
+	await writeFile(seaEntry, entry);
+	await writeFile(
+		seaConfig,
+		`${JSON.stringify(
+			{
+				main: seaEntry,
+				mainFormat: "module",
+				output: executable,
+				disableExperimentalSEAWarning: true,
+				useCodeCache: false,
+				useSnapshot: false,
+			},
+			null,
+			"\t",
+		)}\n`,
+	);
+
+	await run(process.execPath, ["--build-sea", seaConfig]);
+
+	if (process.platform === "darwin") {
+		await run("codesign", ["--sign", "-", executable]);
+	}
+
+	await chmod(executable, 0o755);
+	console.log(`Built ${executable}`);
+}
+
+try {
+	await build();
+} catch (err) {
+	console.error(err instanceof Error ? err.message : err);
+	process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

- add a dependency-free `npm run build:sea` workflow for Node single executable app builds
- generate a standalone SEA entry from the existing CLI/library files so the embedded executable does not depend on filesystem module loading
- document the Node >=25.5 build-time requirement while keeping the package runtime at Node >=24

Closes #8

## Validation

- npm test
- npm run lint
- npm run check
- npm pack --dry-run
- npm run build:sea on Node 24.6.0 cleanly reports the Node >=25.5 build-time requirement
- npx -y -p node@26 node scripts/build-sea.js
- ./dist/mf --help
- ./dist/mf <nested-file> creates the requested file
