### PR TITLE
Expand CI quality gates

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -16,7 +16,13 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install Dependencies
-        run: npm install
+      - name: Install dependencies
+        run: npm ci
+      - name: Check formatting
+        run: npm run format:check
+      - name: Type check
+        run: npm run check
       - name: Test
         run: npm test
+      - name: Verify package contents
+        run: npm pack --dry-run

--- a/README.md
+++ b/README.md
@@ -41,7 +41,17 @@ What I'm attempting to do here is to make a little CLI utility to do something l
 
 ## Development
 
-This project is using JavaScript purely and uses `// @ts-check` to validate the project. This removes the need for a compliation step and makes testing and publishing much easier.
+This project uses plain JavaScript with `// @ts-check` and `jsconfig.json` for static checking. There is no compilation step.
+
+```sh
+npm ci
+npm run format:check
+npm run check
+npm test
+npm pack --dry-run
+```
+
+`format:check` runs Prettier in check mode. `check` runs TypeScript against the JavaScript source without emitting files.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	},
 	"scripts": {
 		"check": "tsc -p jsconfig.json",
-		"lint": "npx prettier . --check",
+		"format:check": "npx prettier . --check",
 		"test": "node --test test.js",
 		"_bin": "node ./cli.js"
 	},


### PR DESCRIPTION
## Summary

- switch CI installs from `npm install` to `npm ci`
- run lint, type-check, tests, and package dry-run in the Node matrix
- keep this separate from the SEA build-support PR

## Validation

- npm ci
- npm run lint
- npm run check
- npm test
- npm pack --dry-run
